### PR TITLE
Ensure hover effect is not applied when disabled

### DIFF
--- a/addon/styles/components/_buttons.scss
+++ b/addon/styles/components/_buttons.scss
@@ -73,7 +73,7 @@ button, .button {
          padding: 0.475rem 1.25rem;
        }
 
-       &:hover {
+       &:hover:not(:disabled) {
          background-color: rgba(theme-get(primary-color), 0.1);
          color: darken(theme-get(primary-color), 10);
        }


### PR DESCRIPTION
## Changes

- Applies a `:not(:disabled)` style to ensure that hovering effect is not applied when button is disabled